### PR TITLE
Custom Text for Access Denied Page updated

### DIFF
--- a/src/Controller/Cwd403Controller.php
+++ b/src/Controller/Cwd403Controller.php
@@ -14,8 +14,8 @@ class Cwd403Controller {
 
   protected function get_markup() {
     $not_logged_in = \Drupal::currentUser()->isAnonymous();
+    $config = \Drupal::config('cwd_custom403.custom403_configuration');
     if($not_logged_in) {
-      $config = \Drupal::config('cwd_custom403.custom403_configuration');
       $markup = "";
       if($config->getRawData()['403_custom_text']) {
         $message = $config->getRawData()['403_custom_text'];
@@ -31,8 +31,11 @@ class Cwd403Controller {
       return $markup;
     }
     else {
-      $current_path = \Drupal::request()->getRequestUri();
-      $markup = '<p>You don\'t have access to this page.</p>';
+      if($config->getRawData()['403_custom_logged_in_text']) {
+        $markup = $config->getRawData()['403_custom_logged_in_text'];
+      } else {
+        $markup = '<p>You don\'t have access to this page.</p>';
+      }
       return $markup;
     }
   }

--- a/src/Form/Custom403Configuration.php
+++ b/src/Form/Custom403Configuration.php
@@ -32,12 +32,21 @@ class Custom403Configuration extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('cwd_custom403.custom403_configuration');
     $form['403_custom_text'] = [
-      '#type' => 'textfield',
+      '#type' => 'textarea',
       '#title' => $this->t('Text for 403 page'),
       '#description' => $this->t('HTML is permitted; shown under page title ("Access denied"). Default: "Restricted access - please login to continue."'),
       '#default_value' => $config->get('403_custom_text'),
       '#size' => 200,
-      '#maxlength' => 255,
+      '#maxlength' => 2000,
+      '#required' => false,
+    ];
+    $form['403_custom_logged_in_text'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Text for 403 page when someone is logged in'),
+      '#description' => $this->t('HTML is permitted; shown under page title ("Access denied"). Default: "Restricted access - please login to continue."'),
+      '#default_value' => $config->get('403_custom_logged_in_text'),
+      '#size' => 200,
+      '#maxlength' => 2000,
       '#required' => false,
     ];
     $form['login_buttons'] = [
@@ -72,9 +81,9 @@ class Custom403Configuration extends ConfigFormBase {
     parent::submitForm($form, $form_state);
     $this->config('cwd_custom403.custom403_configuration')
       ->set('403_custom_text', $form_state->getValue('403_custom_text'))
+      ->set('403_custom_logged_in_text', $form_state->getValue('403_custom_logged_in_text'))
       ->set('403_use_cornell', $form_state->getValue('403_use_cornell'))
       ->set('403_use_drupal', $form_state->getValue('403_use_drupal'))
       ->save();
   }
-
 }


### PR DESCRIPTION
Adding Functionality for custom message for logged in and logged out access denied.

- Increases the size of the allowed text
- Different config for logged in and logged out users

Should be backwards compatible.
